### PR TITLE
fix :  게시물 작성자 탈퇴 시, npe 발생문제 해결

### DIFF
--- a/src/main/java/com/example/kaboocampostproject/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/comment/converter/CommentConverter.java
@@ -17,14 +17,11 @@ public class CommentConverter {
 
     public static CommentSliceItem toSliceItem(CommentDocument comment, MemberProfileCacheDTO authorProfile, boolean isMine) {
 
-        CommentSliceItem.AuthorProfile author = null;
-        if (authorProfile != null) {
-            author = CommentSliceItem.AuthorProfile.builder()
-                    .id(authorProfile.id())
-                    .name(authorProfile.name())
-                    .profileImageObjectKey(authorProfile.profileImageObjectKey())
-                    .build();
-        }
+        CommentSliceItem.AuthorProfile author = CommentSliceItem.AuthorProfile.builder()
+                .id(authorProfile!=null ? authorProfile.id() : null)
+                .name(authorProfile!=null ? authorProfile.name() : "(탈퇴한 사용자)")
+                .profileImageObjectKey(authorProfile!=null ? authorProfile.profileImageObjectKey() : null)
+                .build();
 
         return CommentSliceItem.builder()
                 .commentId(comment.getId())

--- a/src/main/java/com/example/kaboocampostproject/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/post/converter/PostConverter.java
@@ -7,6 +7,7 @@ import com.example.kaboocampostproject.domain.post.dto.req.PostCreatReqDTO;
 import com.example.kaboocampostproject.domain.post.dto.res.PostDetailResDTO;
 import com.example.kaboocampostproject.domain.post.dto.res.PostSimple;
 import com.example.kaboocampostproject.domain.post.dto.res.PostSliceItem;
+import jakarta.annotation.Nullable;
 
 
 public class PostConverter {
@@ -21,9 +22,9 @@ public class PostConverter {
 
     public static PostDetailResDTO toPostDetail(String cdnBaseUrl, PostDocument post, PostLikeStatsDto postLike, Long authorId, MemberProfileCacheDTO profile, boolean isMine) {
         PostDetailResDTO.AuthorProfile authorProfile =  PostDetailResDTO.AuthorProfile.builder()
-                                                        .id(authorId)
-                                                        .name(profile.name())
-                                                        .profileImageObjectKey(profile.profileImageObjectKey())
+                                                        .id(profile!=null ? authorId : null)
+                                                        .name(profile!=null ? profile.name() : "(탈퇴한 사용자)")
+                                                        .profileImageObjectKey(profile!=null ? profile.profileImageObjectKey() : null)
                                                         .build();
 
         return PostDetailResDTO.builder()
@@ -41,16 +42,16 @@ public class PostConverter {
                 .build();
     }
 
-    public static PostSliceItem toPostSliceItem(PostSimple post, PostLikeStatsDto postLike, MemberProfileCacheDTO memberProfile) {
+    public static PostSliceItem toPostSliceItem(PostSimple post, PostLikeStatsDto postLike, @Nullable MemberProfileCacheDTO memberProfile) {
         PostSliceItem.LikeInfo likeInfo = PostSliceItem.LikeInfo.builder()
                 .count(postLike.likeCount())
                 .amILike(postLike.amILike())
                 .build();
 
         PostSliceItem.AuthorProfile author = PostSliceItem.AuthorProfile.builder()
-                .id(memberProfile.id())
-                .name(memberProfile.name())
-                .profileImageObjectKey(memberProfile.profileImageObjectKey())
+                .id(memberProfile!=null ? memberProfile.id() : null)
+                .name(memberProfile!=null ? memberProfile.name() : "(탈퇴한 사용자)")
+                .profileImageObjectKey(memberProfile!=null ? memberProfile.profileImageObjectKey() : null)
                 .build();
 
         return PostSliceItem.builder()

--- a/src/main/java/com/example/kaboocampostproject/domain/post/service/PostMongoService.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/post/service/PostMongoService.java
@@ -257,6 +257,9 @@ public class PostMongoService {
                             post.postId(),
                             new PostLikeStatsDto(post.postId(), 0L, false)
                     );
+                    if (post.authorId()==null){
+                        return PostConverter.toPostSliceItem(post, like, null);
+                    }
                     // 프로필 매칭
                     MemberProfileCacheDTO authorProfile = authorProfiles.get(post.authorId());
                     // 병합


### PR DESCRIPTION
게시물, 댓글 converter에서 profile 을 확인하지 않고 조회하여 NPE 발생

조회 시, null check를 하고, 탈퇴자라면 닉네임에 "(탈퇴한 사용자)" 로 감싸서 반환하여 해결