### PR TITLE
AssignMent : 톰캣 수준의 JWT 필터를 사용하여 인증 구현하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.7.0'
 
+    // passwordEncoder
+    implementation 'org.springframework.security:spring-security-crypto:6.3.3'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/controller/AuthController.java
@@ -1,0 +1,47 @@
+package com.example.kaboocampostproject.domain.auth.controller;
+
+import com.example.kaboocampostproject.domain.auth.dto.req.LoginReqDTO;
+import com.example.kaboocampostproject.domain.auth.dto.res.AccessJwtResDTO;
+import com.example.kaboocampostproject.domain.auth.jwt.dto.IssuedJwts;
+import com.example.kaboocampostproject.domain.auth.jwt.dto.ReissueJwts;
+import com.example.kaboocampostproject.domain.auth.service.AuthMemberService;
+import com.example.kaboocampostproject.global.response.CustomResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthMemberService authMemberService;
+
+    @PostMapping
+    public ResponseEntity<CustomResponse<AccessJwtResDTO>> login(@RequestBody LoginReqDTO loginReqDTO,
+                                                            HttpServletResponse response) {
+        IssuedJwts issued = authMemberService.login(loginReqDTO);
+        // 쿠키 세팅
+        response.addHeader("Set-Cookie", authMemberService.buildRefreshCookie(issued.refreshJwt()).toString());
+        // access jwt 먄 따로 빼서, 응답바디에 반환
+        AccessJwtResDTO accessJwtResDTO = AccessJwtResDTO.buildAccessJwtResDTO(issued);
+        return ResponseEntity.ok(CustomResponse.onSuccess(HttpStatus.OK, accessJwtResDTO));
+    }
+
+    @PutMapping
+    public ResponseEntity<CustomResponse<ReissueJwts>> reissue(HttpServletRequest request) {
+        ReissueJwts issued = authMemberService.reissueJwts(request);
+        return ResponseEntity.ok(CustomResponse.onSuccess(HttpStatus.OK, issued));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<CustomResponse<Void>> logout(HttpServletResponse response){
+        authMemberService.logout(response);
+        return ResponseEntity.ok(CustomResponse.onSuccess(HttpStatus.NO_CONTENT));
+    }
+
+
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/dto/req/LoginReqDTO.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/dto/req/LoginReqDTO.java
@@ -1,0 +1,8 @@
+package com.example.kaboocampostproject.domain.auth.dto.req;
+
+public record LoginReqDTO (
+        String email,
+        String password,
+        String deviceId
+){
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/dto/res/AccessJwtResDTO.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/dto/res/AccessJwtResDTO.java
@@ -1,0 +1,11 @@
+package com.example.kaboocampostproject.domain.auth.dto.res;
+
+import com.example.kaboocampostproject.domain.auth.jwt.dto.IssuedJwts;
+
+public record AccessJwtResDTO(
+        String accessJwt
+) {
+    public static AccessJwtResDTO buildAccessJwtResDTO(IssuedJwts issuedJwts) {
+        return new AccessJwtResDTO(issuedJwts.accessJwt());
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/entity/AuthMember.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/entity/AuthMember.java
@@ -1,0 +1,48 @@
+package com.example.kaboocampostproject.domain.auth.entity;
+
+import com.example.kaboocampostproject.domain.member.entity.Member;
+import com.example.kaboocampostproject.domain.member.entity.UserRole;
+import com.example.kaboocampostproject.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "auth_member")
+@SQLDelete(sql = "UPDATE auth_member SET deleted_at = NOW() WHERE member_id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class AuthMember extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "member_id")
+    private Long id;
+
+    @MapsId //부모 키와 동일한 id 사용
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @Setter
+    private Member member;
+
+    @Column(length = 40, nullable = false, unique = true)
+    private String email;
+
+    @Column(length = 100, nullable = false)
+    private String password;
+    // 최근 비밀번호 변경시간 컬럼 추가
+    // 과거 비밀번호도 별도 테이블 분리 저장 oldPassword( password, createdAt )
+
+    @Enumerated(EnumType.STRING)
+    UserRole role;
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+    public void recoverAuthMember() {
+        this.deletedAt = null;
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/error/AuthMemberErrorCode.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/error/AuthMemberErrorCode.java
@@ -1,0 +1,24 @@
+package com.example.kaboocampostproject.domain.auth.error;
+
+import com.example.kaboocampostproject.global.error.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum AuthMemberErrorCode implements BaseErrorCode {
+
+    // 이메일 인증
+    MEMBER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_01", "이메일이 중복되었습니다"),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_02", "인증 코드가 올바르지 않거나 만료되었습니다"),
+    INVALID_EMAIL_VERIFIED_TOKEN(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_03", "이메일 인증 토큰이 유효하지 않거나 만료되었습니다"),
+
+    // 회원 복구
+    INVALID_RECOVER_MEMBER(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_04", "삭제된 멤버가 아닙니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/error/AuthMemberException.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/error/AuthMemberException.java
@@ -1,0 +1,9 @@
+package com.example.kaboocampostproject.domain.auth.error;
+
+import com.example.kaboocampostproject.global.error.CustomException;
+
+public class AuthMemberException extends CustomException {
+    public AuthMemberException(AuthMemberErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/JwtFilter.java
@@ -1,0 +1,91 @@
+package com.example.kaboocampostproject.domain.auth.jwt;
+
+import com.example.kaboocampostproject.domain.auth.jwt.dto.AccessClaims;
+import com.example.kaboocampostproject.domain.auth.jwt.exception.JwtErrorCode;
+import com.example.kaboocampostproject.domain.auth.jwt.exception.JwtException;
+import com.example.kaboocampostproject.global.error.BaseErrorCode;
+import com.example.kaboocampostproject.global.response.CustomResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    private static final List<String> ALLOWING_URLS = List.of(
+            //docs
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+            // ssr
+            "/policy/**", "/css/**",
+            // 허용 api
+            "/api/auth"
+    );
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException{
+        boolean shouldNotFilter = ALLOWING_URLS.stream().anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
+        if (request.getRequestURI().equals("/api/members") && request.getMethod().equals("POST")) { // 회원가입 요청
+            shouldNotFilter = true;
+        }
+        return shouldNotFilter;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try{
+            // AT추출, null체크
+            String accessToken = extractJwtByHeader(request);
+
+            AccessClaims claims = jwtProvider.parseAndValidateAccess(accessToken);
+            request.setAttribute("memberId", claims.userId());
+
+            filterChain.doFilter(request, response);
+        }catch (JwtException e){
+            BaseErrorCode errorCode = e.getErrorCode();
+            CustomResponse<Void> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage());
+
+            // 응답 직접 작성 후 반환
+            response.addHeader("Access-Control-Allow-Origin", "localhost:3000");
+            response.setStatus(errorCode.getHttpStatus().value());
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write(objectMapper.writeValueAsString(ResponseEntity
+                    .status(errorCode.getHttpStatus())
+                    .body(errorResponse)));
+            return;
+        }
+
+
+    }
+
+    private String extractJwtByHeader(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            throw new JwtException(JwtErrorCode.EMPTY_TOKEN);
+        }
+        return header.substring(7);
+    }
+
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/JwtProvider.java
@@ -1,0 +1,143 @@
+package com.example.kaboocampostproject.domain.auth.jwt;
+
+
+import com.example.kaboocampostproject.domain.auth.jwt.dto.AccessClaims;
+import com.example.kaboocampostproject.domain.auth.jwt.dto.IssuedJwts;
+import com.example.kaboocampostproject.domain.auth.jwt.dto.RefreshClaims;
+import com.example.kaboocampostproject.domain.auth.jwt.exception.JwtErrorCode;
+import com.example.kaboocampostproject.domain.auth.jwt.exception.JwtException;
+import com.example.kaboocampostproject.domain.member.entity.UserRole;
+import com.example.kaboocampostproject.global.metadata.JwtMetadata;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final SecretKey signingKey;
+
+    private static final String JWT_TYPE = "typ";
+    private static final String ROLE = "role";
+    private static final String DEVICE_ID = "did";
+    private static final String REFRESH_VERSION = "ver";
+
+    // Claim 추출
+    private Claims parse(String jwt) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(signingKey)
+                    .build()
+                    .parseSignedClaims(jwt)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new JwtException(JwtErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new JwtException(JwtErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    public AccessClaims parseAndValidateAccess(String accessJwt) {
+
+        Claims c = parse(accessJwt);
+
+        // access 여부 체크
+        String jwtType = c.get(JWT_TYPE, String.class);
+        if (!jwtType.equals(JwtMetadata.ACCESS_JWT.getJwtType())) {
+            throw new JwtException(JwtErrorCode.TOKEN_TYPE_MISMATCH);
+        }
+
+        Long userId = Long.parseLong(c.getSubject()); // userId 문자열
+        UserRole userRole = UserRole.valueOf(c.get(ROLE, String.class));
+
+        if (userId == 0L) {
+            throw new JwtException(JwtErrorCode.MISSING_CLAIMS);
+        }
+
+        return new AccessClaims(userId, userRole);
+    }
+
+    public RefreshClaims parseAndValidateRefresh(String refreshJwt) {
+
+        Claims c = parse(refreshJwt);
+
+        // refresh 여부 체크
+        String jwtType = c.get(JWT_TYPE, String.class);
+        if (!jwtType.equals(JwtMetadata.REFRESH_JWT.getJwtType())) {
+            throw new JwtException(JwtErrorCode.TOKEN_TYPE_MISMATCH);
+        }
+
+        Date exp = c.getExpiration();
+
+        Long userId = Long.parseLong(c.getSubject()); // userId 문자열
+        String deviceId = c.get(DEVICE_ID, String.class);
+        UserRole userRole = UserRole.valueOf(c.get(ROLE, String.class));
+        String refreshVersion = c.get(REFRESH_VERSION, String.class);
+
+        if (userId == 0L || deviceId == null || refreshVersion == null) {
+            throw new JwtException(JwtErrorCode.MISSING_CLAIMS);
+        }
+
+        return new RefreshClaims(userId, userRole, deviceId, refreshVersion, exp.toInstant());
+    }
+
+
+    public IssuedJwts issueJwts(Long userId, UserRole userRole, String deviceId, @Nullable Instant issuedAt) {
+
+        String accessJwt = buildAccessJwt(userId, userRole);
+        String refreshJwt = buildRefreshJwt(userId, userRole, deviceId, null, issuedAt);
+
+        return IssuedJwts.builder()
+                .accessJwt(accessJwt)
+                .refreshJwt(refreshJwt)
+                .build();
+    }
+
+    public String buildAccessJwt(Long userId, UserRole userRole) {
+
+        Instant now = Instant.now();
+        Instant expiration = now.plusSeconds(JwtMetadata.ACCESS_JWT.getTtlSeconds());
+
+        return Jwts.builder()
+                .subject(Long.toString(userId))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiration))
+                .claim(JWT_TYPE, JwtMetadata.ACCESS_JWT.getJwtType())
+                .claim(ROLE, userRole)
+                .signWith(signingKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public String buildRefreshJwt(Long userId, UserRole userRole, String deviceId, @Nullable String refreshVersion, @Nullable Instant issuedAt) {
+
+        Instant now = (issuedAt != null) ? issuedAt : Instant.now(); // 재 발급 or 첫 발급
+        Instant expiration = now.plusSeconds(JwtMetadata.REFRESH_JWT.getTtlSeconds());
+
+        // 리프레시 토큰용 발급 로직
+        return Jwts.builder()
+                .subject(Long.toString(userId))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiration))
+                .claim(JWT_TYPE, JwtMetadata.REFRESH_JWT.getJwtType())
+                .claim(ROLE, userRole)
+                .claim(DEVICE_ID, deviceId)
+                .claim(REFRESH_VERSION, (refreshVersion==null)? UUID.randomUUID().toString(): refreshVersion)
+                .signWith(signingKey, Jwts.SIG.HS256)
+                .compact();
+
+    }
+
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/anotations/MemberIdInfo.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/anotations/MemberIdInfo.java
@@ -1,0 +1,12 @@
+package com.example.kaboocampostproject.domain.auth.jwt.anotations;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Parameter(hidden = true)
+public @interface MemberIdInfo {
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/anotations/resolver/MemberIdArgumentResolver.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/anotations/resolver/MemberIdArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.example.kaboocampostproject.domain.auth.jwt.anotations.resolver;
+
+import com.example.kaboocampostproject.domain.auth.jwt.JwtProvider;
+import com.example.kaboocampostproject.domain.auth.jwt.anotations.MemberIdInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberIdInfo.class) && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return request.getAttribute("memberId");
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/dto/AccessClaims.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/dto/AccessClaims.java
@@ -1,0 +1,9 @@
+package com.example.kaboocampostproject.domain.auth.jwt.dto;
+
+import com.example.kaboocampostproject.domain.member.entity.UserRole;
+
+public record AccessClaims(
+        long userId,
+        UserRole userRole
+) {
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/dto/IssuedJwts.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/dto/IssuedJwts.java
@@ -1,0 +1,10 @@
+package com.example.kaboocampostproject.domain.auth.jwt.dto;
+
+import lombok.Builder;
+
+@Builder
+public record IssuedJwts(
+        String accessJwt,
+        String refreshJwt
+){
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/dto/RefreshClaims.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/dto/RefreshClaims.java
@@ -1,0 +1,14 @@
+package com.example.kaboocampostproject.domain.auth.jwt.dto;
+
+import com.example.kaboocampostproject.domain.member.entity.UserRole;
+
+import java.time.Instant;
+
+// Refresh 토큰에서 뽑은 클레임
+public record RefreshClaims(
+        Long    userId,
+        UserRole  userRole,
+        String  deviceId,
+        String  refreshVersion,
+        Instant expiresAt
+) {}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/dto/ReissueJwts.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/dto/ReissueJwts.java
@@ -1,0 +1,6 @@
+package com.example.kaboocampostproject.domain.auth.jwt.dto;
+
+public record ReissueJwts (
+        String accessJwt
+){
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/exception/JwtErrorCode.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/exception/JwtErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.kaboocampostproject.domain.auth.jwt.exception;
+
+
+import com.example.kaboocampostproject.global.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum JwtErrorCode implements BaseErrorCode {
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "JWT403_01", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT403_02", "만료된 토큰입니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "JWT403_03", "접근 권한이 없습니다."),
+
+    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "JWT401_01", "토큰이 비어있습니다."),
+    TOKEN_TYPE_MISMATCH(HttpStatus.UNAUTHORIZED, "JWT401_02", "토큰 타입이 올바르지 않습니다."),
+    MISSING_CLAIMS(HttpStatus.UNAUTHORIZED, "JWT401_03", "필수 클레임이 누락되었습니다."),
+    ID_PARSE_FAIL(HttpStatus.UNAUTHORIZED, "JWT401_04", "아이디 파싱 실패"),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/exception/JwtException.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/jwt/exception/JwtException.java
@@ -1,0 +1,14 @@
+package com.example.kaboocampostproject.domain.auth.jwt.exception;
+
+import com.example.kaboocampostproject.global.error.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class JwtException extends RuntimeException{
+    BaseErrorCode errorCode;
+    public JwtException(BaseErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}
+
+

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/repository/AuthMemberRepository.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/repository/AuthMemberRepository.java
@@ -1,0 +1,21 @@
+package com.example.kaboocampostproject.domain.auth.repository;
+
+import com.example.kaboocampostproject.domain.auth.entity.AuthMember;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface AuthMemberRepository extends JpaRepository<AuthMember, Long> {
+
+    Optional<AuthMember> findByMemberId(Long memberId);
+    @Query(
+            value = "SELECT * FROM auth_member WHERE email = :email",
+            nativeQuery = true
+    )
+    AuthMember findByEmailWithDeleted(@Param("email") String email);
+
+    Optional<AuthMember> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/service/AuthMemberService.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/service/AuthMemberService.java
@@ -1,0 +1,107 @@
+package com.example.kaboocampostproject.domain.auth.service;
+
+import com.example.kaboocampostproject.domain.auth.dto.req.LoginReqDTO;
+import com.example.kaboocampostproject.domain.auth.entity.AuthMember;
+import com.example.kaboocampostproject.domain.auth.error.AuthMemberErrorCode;
+import com.example.kaboocampostproject.domain.auth.error.AuthMemberException;
+import com.example.kaboocampostproject.domain.auth.jwt.JwtProvider;
+import com.example.kaboocampostproject.domain.auth.jwt.dto.IssuedJwts;
+import com.example.kaboocampostproject.domain.auth.jwt.dto.RefreshClaims;
+import com.example.kaboocampostproject.domain.auth.jwt.dto.ReissueJwts;
+import com.example.kaboocampostproject.domain.auth.repository.AuthMemberRepository;
+import com.example.kaboocampostproject.domain.member.dto.request.UpdateMemberReqDTO;
+import com.example.kaboocampostproject.domain.member.error.MemberErrorCode;
+import com.example.kaboocampostproject.domain.member.error.MemberException;
+import com.example.kaboocampostproject.global.metadata.JwtMetadata;
+import com.example.kaboocampostproject.global.metadata.RedisMetadata;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class AuthMemberService {
+    private final AuthMemberRepository authMemberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    private static final String REFRESH_COOKIE_PATH = "/api/auth";
+
+    @Transactional(readOnly = true)
+    public IssuedJwts login(LoginReqDTO dto) {
+        AuthMember authMember = authMemberRepository.findByEmail(dto.email()).orElseThrow(()->
+                new MemberException(MemberErrorCode.PASSWORD_AND_EMAIL_NOT_MATCH)); // 이메일을 알아낼 수 없도록
+
+        if (!passwordEncoder.matches(dto.password(), authMember.getPassword())) {
+            throw new MemberException(MemberErrorCode.PASSWORD_AND_EMAIL_NOT_MATCH);
+        }
+        return jwtProvider.issueJwts(authMember.getId(), authMember.getRole(), dto.deviceId(), null);
+    }
+
+    public ResponseCookie buildRefreshCookie(String refreshToken) {
+        return ResponseCookie.from(JwtMetadata.REFRESH_JWT.getJwtType(), refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path(REFRESH_COOKIE_PATH)
+                .maxAge(JwtMetadata.REFRESH_JWT.getTtlSeconds())
+                .build();
+    }
+
+    public ReissueJwts reissueJwts(HttpServletRequest req) {
+        String refreshJwt = extractRefreshFromCookie(req);
+        RefreshClaims refreshClaims = jwtProvider.parseAndValidateRefresh(refreshJwt);
+
+        String accessJwt = jwtProvider.buildAccessJwt(
+                                refreshClaims.userId(),
+                                refreshClaims.userRole());
+        return new ReissueJwts(accessJwt);
+
+    }
+    // 쿠키에서 jwt 파싱
+    private String extractRefreshFromCookie(HttpServletRequest req) {
+        return Arrays.stream(Optional.ofNullable(req.getCookies()).orElse(new Cookie[0]))
+                .filter(c -> JwtMetadata.REFRESH_JWT.getJwtType().equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public void logout(HttpServletResponse response) {
+        // 멱등성 보장 위해서 검증하지 않고 삭제
+        expireRefreshCookie(response);//쿠키 삭제
+    }
+
+    private void expireRefreshCookie(HttpServletResponse response) {
+        ResponseCookie expired = ResponseCookie.from(JwtMetadata.REFRESH_JWT.getJwtType(), "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path(REFRESH_COOKIE_PATH)
+                .maxAge(Duration.ZERO)
+                .build();
+        response.addHeader("Set-Cookie", expired.toString());
+    }
+
+    @Transactional
+    public void updatePassword(Long memberId, UpdateMemberReqDTO.MemberPassword password) {
+        AuthMember authMember = authMemberRepository.findById(memberId).orElseThrow(()->
+                new MemberException(MemberErrorCode.MEMBER_NOT_FOND));
+
+        if (!passwordEncoder.matches(password.oldPassword(), authMember.getPassword())) {
+            throw new MemberException(MemberErrorCode.PASSWORD_NOT_MATCH);
+        }
+        String encodedPassword = passwordEncoder.encode(password.newPassword());
+        authMember.updatePassword(encodedPassword);
+    }
+
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.example.kaboocampostproject.domain.member.service;
 
-import com.example.kaboocampostproject.domain.auth.email.EmailVerifier;
 import com.example.kaboocampostproject.domain.auth.entity.AuthMember;
 import com.example.kaboocampostproject.domain.auth.repository.AuthMemberRepository;
 import com.example.kaboocampostproject.domain.like.entity.PostLike;

--- a/src/main/java/com/example/kaboocampostproject/global/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/example/kaboocampostproject/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,13 @@
+package com.example.kaboocampostproject.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/global/config/WebFilterConfig.java
+++ b/src/main/java/com/example/kaboocampostproject/global/config/WebFilterConfig.java
@@ -1,0 +1,34 @@
+package com.example.kaboocampostproject.global.config;
+
+import com.example.kaboocampostproject.domain.auth.jwt.JwtFilter;
+import jakarta.servlet.Filter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebFilterConfig {
+    private final JwtFilter jwtFilter;
+
+    @Bean
+    public FilterRegistrationBean<Filter> corsFilterRegistrationBean(CorsConfigurationSource  corsConfigurationSource) {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new CorsFilter(corsConfigurationSource));
+        filterRegistrationBean.addUrlPatterns("/*");
+        filterRegistrationBean.setOrder(0);
+        return filterRegistrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<Filter> jwtFilterRegistrationBean() {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(jwtFilter);
+        filterRegistrationBean.addUrlPatterns("/*");
+        filterRegistrationBean.setOrder(1);
+        return filterRegistrationBean;
+    }
+}


### PR DESCRIPTION
톰캣 수준의 jwtFilter를 사용하여 인증 구현하기

1. AT는 인증헤더에 담아 일반적인 api 인증요청에서 사용하였습니다.
2. AT 만료 시 PATCH "/api/auth" 의 토큰 재발급 전용 api를 추가 구성하여, 해당 api에만 RT 쿠키를 전송하도록 구성하였습니다.
CSRF 공격시, 공격 표면을 줄이기 위해서 해당 방식을 사용하였습니다.

필터는 서블릿 컨테이너 수준의 필터를 사용하여, 예외 시, 필터에서 직접 응답을 내려주는 방식을 사용하였습니다.