### PR TITLE
assignment : session - cookie 방식을 사용한 인증필터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.7.0'
 
+    // passwordEncoder
+    implementation 'org.springframework.security:spring-security-crypto:6.3.3'
+
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/anotations/MemberIdInfo.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/anotations/MemberIdInfo.java
@@ -1,0 +1,12 @@
+package com.example.kaboocampostproject.domain.auth.anotations;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Parameter(hidden = true)
+public @interface MemberIdInfo {
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/anotations/resolver/MemberIdArgumentResolver.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/anotations/resolver/MemberIdArgumentResolver.java
@@ -1,0 +1,29 @@
+package com.example.kaboocampostproject.domain.auth.anotations.resolver;
+
+import com.example.kaboocampostproject.domain.auth.anotations.MemberIdInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberIdInfo.class) && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return request.getAttribute("memberId");
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.example.kaboocampostproject.domain.auth.controller;
+
+import com.example.kaboocampostproject.domain.auth.dto.req.LoginReqDTO;
+import com.example.kaboocampostproject.domain.auth.service.AuthMemberService;
+import com.example.kaboocampostproject.global.response.CustomResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthMemberService authMemberService;
+
+    @PostMapping
+    public ResponseEntity<CustomResponse<Void>> login(@RequestBody LoginReqDTO loginReqDTO,
+                                                            HttpServletResponse response) {
+        authMemberService.login(response, loginReqDTO);
+        return ResponseEntity.ok(CustomResponse.onSuccess(HttpStatus.CREATED));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<CustomResponse<Void>> logout(HttpServletResponse response){
+        authMemberService.logout(response);
+        return ResponseEntity.ok(CustomResponse.onSuccess(HttpStatus.NO_CONTENT));
+    }
+
+
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/dto/req/LoginReqDTO.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/dto/req/LoginReqDTO.java
@@ -1,0 +1,8 @@
+package com.example.kaboocampostproject.domain.auth.dto.req;
+
+public record LoginReqDTO (
+        String email,
+        String password,
+        String deviceId
+){
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/entity/AuthMember.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/entity/AuthMember.java
@@ -1,0 +1,48 @@
+package com.example.kaboocampostproject.domain.auth.entity;
+
+import com.example.kaboocampostproject.domain.member.entity.Member;
+import com.example.kaboocampostproject.domain.member.entity.UserRole;
+import com.example.kaboocampostproject.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "auth_member")
+@SQLDelete(sql = "UPDATE auth_member SET deleted_at = NOW() WHERE member_id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class AuthMember extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "member_id")
+    private Long id;
+
+    @MapsId //부모 키와 동일한 id 사용
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @Setter
+    private Member member;
+
+    @Column(length = 40, nullable = false, unique = true)
+    private String email;
+
+    @Column(length = 100, nullable = false)
+    private String password;
+    // 최근 비밀번호 변경시간 컬럼 추가
+    // 과거 비밀번호도 별도 테이블 분리 저장 oldPassword( password, createdAt )
+
+    @Enumerated(EnumType.STRING)
+    UserRole role;
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+    public void recoverAuthMember() {
+        this.deletedAt = null;
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/error/AuthMemberErrorCode.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/error/AuthMemberErrorCode.java
@@ -1,0 +1,30 @@
+package com.example.kaboocampostproject.domain.auth.error;
+
+import com.example.kaboocampostproject.global.error.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum AuthMemberErrorCode implements BaseErrorCode {
+
+    // 이메일 인증
+    MEMBER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_01", "이메일이 중복되었습니다"),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_02", "인증 코드가 올바르지 않거나 만료되었습니다"),
+    INVALID_EMAIL_VERIFIED_TOKEN(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_03", "이메일 인증 토큰이 유효하지 않거나 만료되었습니다"),
+
+    // 회원 복구
+    INVALID_RECOVER_MEMBER(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_04", "삭제된 멤버가 아닙니다."),
+
+    INVALID_SESSION_ID(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_05", "유효하지 않은 형식의 세션아이디입니다."),
+    SESSION_BLACKLISTED(HttpStatus.BAD_REQUEST, "AUTHMEMBER_401_06", "세션 탈취로 블랙리스트 처리되었습니다."),
+    LOGIN_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTHMEMBER_404_01", "세션에 인증정보가 없습니다"),
+
+    EMPTY_SESSIONID_IN_COOKIE(HttpStatus.NOT_FOUND, "AUTHMEMBER_404_02", "세션아이디 쿠키기 비어있습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/error/AuthMemberException.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/error/AuthMemberException.java
@@ -1,0 +1,9 @@
+package com.example.kaboocampostproject.domain.auth.error;
+
+import com.example.kaboocampostproject.global.error.CustomException;
+
+public class AuthMemberException extends CustomException {
+    public AuthMemberException(AuthMemberErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/repository/AuthMemberRepository.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/repository/AuthMemberRepository.java
@@ -1,0 +1,21 @@
+package com.example.kaboocampostproject.domain.auth.repository;
+
+import com.example.kaboocampostproject.domain.auth.entity.AuthMember;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface AuthMemberRepository extends JpaRepository<AuthMember, Long> {
+
+    Optional<AuthMember> findByMemberId(Long memberId);
+    @Query(
+            value = "SELECT * FROM auth_member WHERE email = :email",
+            nativeQuery = true
+    )
+    AuthMember findByEmailWithDeleted(@Param("email") String email);
+
+    Optional<AuthMember> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/service/AuthMemberService.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/service/AuthMemberService.java
@@ -1,0 +1,82 @@
+package com.example.kaboocampostproject.domain.auth.service;
+
+import com.example.kaboocampostproject.domain.auth.dto.req.LoginReqDTO;
+import com.example.kaboocampostproject.domain.auth.entity.AuthMember;
+import com.example.kaboocampostproject.domain.auth.repository.AuthMemberRepository;
+import com.example.kaboocampostproject.domain.auth.session.SessionManager;
+import com.example.kaboocampostproject.domain.member.dto.request.UpdateMemberReqDTO;
+import com.example.kaboocampostproject.domain.member.error.MemberErrorCode;
+import com.example.kaboocampostproject.domain.member.error.MemberException;
+import com.example.kaboocampostproject.global.metadata.JwtMetadata;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+import static com.example.kaboocampostproject.domain.auth.session.SessionFilter.SESSION_ID;
+
+@RequiredArgsConstructor
+@Service
+public class AuthMemberService {
+    private final AuthMemberRepository authMemberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final SessionManager sessionManager;
+
+
+    @Transactional(readOnly = true)
+    public void login(HttpServletResponse response, LoginReqDTO dto) {
+        AuthMember authMember = authMemberRepository.findByEmail(dto.email()).orElseThrow(()->
+                new MemberException(MemberErrorCode.PASSWORD_AND_EMAIL_NOT_MATCH)); // 이메일을 알아낼 수 없도록
+
+        if (!passwordEncoder.matches(dto.password(), authMember.getPassword())) {
+            throw new MemberException(MemberErrorCode.PASSWORD_AND_EMAIL_NOT_MATCH);
+        }
+
+        String sessionId = sessionManager.storeAuthentication(authMember.getId(), authMember.getRole());
+
+        setCookie(response, sessionId);
+    }
+
+    private void setCookie(HttpServletResponse response, String sessionId) {
+        ResponseCookie cookie = ResponseCookie.from(SESSION_ID, sessionId)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+    public void logout(HttpServletResponse response) {
+        // 세션 인증 삭제
+        sessionManager.removeAuthentication(SESSION_ID);
+        expireRefreshCookie(response);//쿠키 삭제
+    }
+
+    private void expireRefreshCookie(HttpServletResponse response) {
+        ResponseCookie expired = ResponseCookie.from(JwtMetadata.REFRESH_JWT.getJwtType(), "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .maxAge(Duration.ZERO)
+                .build();
+        response.addHeader("Set-Cookie", expired.toString());
+    }
+
+    @Transactional
+    public void updatePassword(Long memberId, UpdateMemberReqDTO.MemberPassword password) {
+        AuthMember authMember = authMemberRepository.findById(memberId).orElseThrow(()->
+                new MemberException(MemberErrorCode.MEMBER_NOT_FOND));
+
+        if (!passwordEncoder.matches(password.oldPassword(), authMember.getPassword())) {
+            throw new MemberException(MemberErrorCode.PASSWORD_NOT_MATCH);
+        }
+        String encodedPassword = passwordEncoder.encode(password.newPassword());
+        authMember.updatePassword(encodedPassword);
+    }
+
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/session/SessionFilter.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/session/SessionFilter.java
@@ -1,0 +1,109 @@
+package com.example.kaboocampostproject.domain.auth.session;
+
+import com.example.kaboocampostproject.domain.auth.error.AuthMemberErrorCode;
+import com.example.kaboocampostproject.domain.auth.error.AuthMemberException;
+import com.example.kaboocampostproject.domain.auth.session.dto.UserAuthentication;
+import com.example.kaboocampostproject.global.error.BaseErrorCode;
+import com.example.kaboocampostproject.global.response.CustomResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class SessionFilter extends OncePerRequestFilter {
+
+    private final SessionManager sessionManager;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    public static final String SESSION_ID = "SESSIONID";
+    private static final List<String> ALLOWING_URLS = List.of(
+            //docs
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+            // ssr
+            "/policy/**", "/css/**",
+            // 허용 api
+            "/api/auth"
+    );
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException{
+        boolean shouldNotFilter = ALLOWING_URLS.stream().anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
+        if (request.getRequestURI().equals("/api/members") && request.getMethod().equals("POST")) { // 회원가입 요청
+            shouldNotFilter = true;
+        }
+        return shouldNotFilter;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try{
+            // sessionId 추출, null체크
+            String sessionId = extractSessionIdByCookie(request);
+
+            UserAuthentication userAuthentication = sessionManager.verifyAuthentication(sessionId);
+            request.setAttribute("memberId", userAuthentication.memberId());
+
+            // 세션id 교체(tag만)
+            setCookie(response, userAuthentication.sessionId());
+
+            filterChain.doFilter(request, response);
+        }catch (AuthMemberException e){
+            BaseErrorCode errorCode = e.getErrorCode();
+            CustomResponse<Void> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage());
+
+            // 응답 직접 작성 후 반환
+            response.addHeader("Access-Control-Allow-Origin", "localhost:3000");
+            response.setStatus(errorCode.getHttpStatus().value());
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write(objectMapper.writeValueAsString(ResponseEntity
+                    .status(errorCode.getHttpStatus())
+                    .body(errorResponse)));
+            return;
+        }
+
+
+    }
+
+    private String extractSessionIdByCookie(HttpServletRequest request) {
+
+        return Arrays.stream(Optional.ofNullable(request.getCookies()).orElseThrow(() ->
+                        new AuthMemberException(AuthMemberErrorCode.EMPTY_SESSIONID_IN_COOKIE)))
+                .filter(cookie -> SESSION_ID.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow(() -> new AuthMemberException(AuthMemberErrorCode.EMPTY_SESSIONID_IN_COOKIE));
+
+    }
+
+    private void setCookie(HttpServletResponse response, String sessionId) {
+        ResponseCookie cookie = ResponseCookie.from(SESSION_ID, sessionId)
+                                .httpOnly(true)
+                                .secure(true)
+                                .sameSite("Strict")
+                                .path("/")
+                                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/session/SessionManager.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/session/SessionManager.java
@@ -1,0 +1,112 @@
+package com.example.kaboocampostproject.domain.auth.session;
+
+import com.example.kaboocampostproject.domain.auth.error.AuthMemberErrorCode;
+import com.example.kaboocampostproject.domain.auth.error.AuthMemberException;
+import com.example.kaboocampostproject.domain.auth.session.dto.ParsedSessionId;
+import com.example.kaboocampostproject.domain.auth.session.dto.UserAuthentication;
+import com.example.kaboocampostproject.domain.member.entity.UserRole;
+import com.example.kaboocampostproject.global.metadata.RedisMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class SessionManager {
+    private final StringRedisTemplate redisTemplate;
+
+    private final static String TAG = "tag";
+    private final static String MEMBER_ID = "mid";
+    private final static String MEMBER_ROLE = "role";
+
+    private final static RedisMetadata meta = RedisMetadata.LOGIN_SESSION;
+
+
+    // 로그인
+    public String storeAuthentication(Long memberId, UserRole role) {
+
+        Map<String, Object> map = new HashMap<>();
+
+        String sessionKey = UUID.randomUUID().toString();
+        String redisKey = meta.keyOf(sessionKey);
+
+        String tag = generateTag();
+
+        // 정보 저장
+        map.put(TAG, tag);
+        map.put(MEMBER_ID, memberId.toString());
+        map.put(MEMBER_ROLE, role.name());
+
+        redisTemplate.opsForHash().putAll(redisKey, map);
+        redisTemplate.expire(redisKey, meta.getTtl());
+
+        return sessionKey + "." + tag;
+    }
+
+    private String generateTag() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+
+    // 세션 아이디 파싱
+    private ParsedSessionId parseSessionId(String sessionId) {
+        int dot = sessionId.indexOf('.');
+        if (dot < 0) {
+            throw new AuthMemberException(AuthMemberErrorCode.INVALID_SESSION_ID);
+        }
+        String sessionKey = sessionId.substring(0, dot);
+        String tag = sessionId.substring(dot + 1);
+        return new ParsedSessionId(sessionKey, tag);
+    }
+
+    // 인증 -> 인가정보 반환
+    public UserAuthentication verifyAuthentication(String sessionId) {
+        // 세션정보 꺼내기
+        ParsedSessionId  parsedSessionId = parseSessionId(sessionId);
+        String redisKey = meta.keyOf(parsedSessionId.sessionKey());
+
+        Map<Object, Object> memberSessionMap = redisTemplate.opsForHash().entries(redisKey);
+        if (memberSessionMap.isEmpty()) {
+            throw new AuthMemberException(AuthMemberErrorCode.LOGIN_SESSION_NOT_FOUND);
+        }
+
+        // 널 체크
+        String stringMemberId = memberSessionMap.get(MEMBER_ID).toString();
+        String stringRole = memberSessionMap.get(MEMBER_ROLE).toString();
+        String stringTag = memberSessionMap.get(TAG).toString();
+
+        if (stringMemberId==null || stringRole==null || stringTag==null) {
+            throw new AuthMemberException(AuthMemberErrorCode.LOGIN_SESSION_NOT_FOUND);
+        }
+
+        // 테그 검증
+        if (!memberSessionMap.get(TAG).equals(parsedSessionId.tag())) {
+            // 세션 블랙리스트
+            redisTemplate.delete(redisKey);
+            throw new AuthMemberException(AuthMemberErrorCode.SESSION_BLACKLISTED);
+        }
+
+        // 테그 회전
+        String newTag = generateTag();
+        redisTemplate.opsForHash().put(redisKey, TAG, newTag);
+        // 세션아이디 생성
+        String newSessionId = parsedSessionId.sessionKey() + "." + newTag;
+
+
+        Long memberId = Long.parseLong(stringMemberId);
+        UserRole role = UserRole.of(stringRole);
+
+        return UserAuthentication.of(newSessionId, memberId, role);
+
+    }
+
+    // 로그아웃
+    public void removeAuthentication(String sessionId) {
+        ParsedSessionId  parsedSessionId = parseSessionId(sessionId);
+        String redisKey = meta.keyOf(parsedSessionId.sessionKey());
+        redisTemplate.delete(redisKey);
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/session/dto/ParsedSessionId.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/session/dto/ParsedSessionId.java
@@ -1,0 +1,7 @@
+package com.example.kaboocampostproject.domain.auth.session.dto;
+
+public record ParsedSessionId (
+        String sessionKey,
+        String tag
+) {
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/auth/session/dto/UserAuthentication.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/auth/session/dto/UserAuthentication.java
@@ -1,0 +1,19 @@
+package com.example.kaboocampostproject.domain.auth.session.dto;
+
+import com.example.kaboocampostproject.domain.member.entity.UserRole;
+import lombok.Builder;
+
+@Builder
+public record UserAuthentication (
+        String sessionId,
+        Long memberId,
+        UserRole role
+) {
+    public static UserAuthentication of (String sessionId, Long memberId, UserRole role) {
+        return UserAuthentication.builder()
+                .sessionId(sessionId)
+                .memberId(memberId)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/comment/controller/CommentController.java
@@ -1,6 +1,6 @@
 package com.example.kaboocampostproject.domain.comment.controller;
 
-import com.example.kaboocampostproject.domain.auth.jwt.anotations.MemberIdInfo;
+import com.example.kaboocampostproject.domain.auth.anotations.MemberIdInfo;
 import com.example.kaboocampostproject.domain.comment.dto.CommentReqDTO;
 import com.example.kaboocampostproject.domain.comment.dto.CommentSliceResDTO;
 import com.example.kaboocampostproject.domain.comment.service.CommentMongoService;

--- a/src/main/java/com/example/kaboocampostproject/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/member/controller/MemberController.java
@@ -1,14 +1,12 @@
 package com.example.kaboocampostproject.domain.member.controller;
 
-import com.example.kaboocampostproject.domain.auth.jwt.anotations.MemberIdInfo;
+import com.example.kaboocampostproject.domain.auth.anotations.MemberIdInfo;
 import com.example.kaboocampostproject.domain.auth.service.AuthMemberService;
 import com.example.kaboocampostproject.domain.member.dto.request.MemberRegisterReqDTO;
-import com.example.kaboocampostproject.domain.member.dto.request.RecoverMemberReqDTO;
 import com.example.kaboocampostproject.domain.member.dto.request.UpdateMemberReqDTO;
 import com.example.kaboocampostproject.domain.member.dto.response.MemberProfileAndEmailResDTO;
 import com.example.kaboocampostproject.domain.member.service.MemberService;
 import com.example.kaboocampostproject.global.response.CustomResponse;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/kaboocampostproject/domain/member/entity/UserRole.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/member/entity/UserRole.java
@@ -2,5 +2,9 @@ package com.example.kaboocampostproject.domain.member.entity;
 
 public enum UserRole {
     ROLE_USER,
-    ROLE_ADMIN
+    ROLE_ADMIN;
+
+    public static UserRole of(String role) {
+        return UserRole.valueOf(role);
+    }
 }

--- a/src/main/java/com/example/kaboocampostproject/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.example.kaboocampostproject.domain.member.service;
 
-import com.example.kaboocampostproject.domain.auth.email.EmailVerifier;
 import com.example.kaboocampostproject.domain.auth.entity.AuthMember;
 import com.example.kaboocampostproject.domain.auth.repository.AuthMemberRepository;
 import com.example.kaboocampostproject.domain.like.entity.PostLike;

--- a/src/main/java/com/example/kaboocampostproject/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/post/controller/PostController.java
@@ -1,10 +1,9 @@
 package com.example.kaboocampostproject.domain.post.controller;
 
-import com.example.kaboocampostproject.domain.auth.jwt.anotations.MemberIdInfo;
+import com.example.kaboocampostproject.domain.auth.anotations.MemberIdInfo;
 import com.example.kaboocampostproject.domain.post.dto.req.PostCreatReqDTO;
 import com.example.kaboocampostproject.domain.post.dto.req.PostUpdateReqDTO;
 import com.example.kaboocampostproject.domain.post.dto.res.PostDetailResDTO;
-import com.example.kaboocampostproject.domain.post.dto.res.PostSliceItem;
 import com.example.kaboocampostproject.domain.post.dto.res.PostSliceResDTO;
 import com.example.kaboocampostproject.domain.post.service.PostMongoService;
 import com.example.kaboocampostproject.global.cursor.Cursor;

--- a/src/main/java/com/example/kaboocampostproject/domain/s3/controller/S3Controller.java
+++ b/src/main/java/com/example/kaboocampostproject/domain/s3/controller/S3Controller.java
@@ -1,7 +1,6 @@
 package com.example.kaboocampostproject.domain.s3.controller;
 
 
-import com.example.kaboocampostproject.domain.auth.jwt.anotations.MemberIdInfo;
 import com.example.kaboocampostproject.domain.s3.dto.req.UploadListReqDTO;
 import com.example.kaboocampostproject.domain.s3.dto.req.UploadReqDTO;
 import com.example.kaboocampostproject.domain.s3.dto.res.PresignedUrlListResDTO;

--- a/src/main/java/com/example/kaboocampostproject/global/config/PasswordConfig.java
+++ b/src/main/java/com/example/kaboocampostproject/global/config/PasswordConfig.java
@@ -1,0 +1,14 @@
+package com.example.kaboocampostproject.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/global/config/WebConfig.java
+++ b/src/main/java/com/example/kaboocampostproject/global/config/WebConfig.java
@@ -1,6 +1,6 @@
 package com.example.kaboocampostproject.global.config;
 
-import com.example.kaboocampostproject.domain.auth.jwt.anotations.resolver.MemberIdArgumentResolver;
+import com.example.kaboocampostproject.domain.auth.anotations.resolver.MemberIdArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;

--- a/src/main/java/com/example/kaboocampostproject/global/config/WebFilterConfig.java
+++ b/src/main/java/com/example/kaboocampostproject/global/config/WebFilterConfig.java
@@ -1,0 +1,34 @@
+package com.example.kaboocampostproject.global.config;
+
+import com.example.kaboocampostproject.domain.auth.session.SessionFilter;
+import jakarta.servlet.Filter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebFilterConfig {
+    private final SessionFilter sessionFilter;
+
+    @Bean
+    public FilterRegistrationBean<Filter> corsFilterRegistrationBean(CorsConfigurationSource  corsConfigurationSource) {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new CorsFilter(corsConfigurationSource));
+        filterRegistrationBean.addUrlPatterns("/*");
+        filterRegistrationBean.setOrder(0);
+        return filterRegistrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<Filter> jwtFilterRegistrationBean() {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(sessionFilter);
+        filterRegistrationBean.addUrlPatterns("/*");
+        filterRegistrationBean.setOrder(1);
+        return filterRegistrationBean;
+    }
+}

--- a/src/main/java/com/example/kaboocampostproject/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/kaboocampostproject/global/error/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.example.kaboocampostproject.global.error;
 
-import com.example.kaboocampostproject.domain.auth.jwt.exception.JwtException;
 import com.example.kaboocampostproject.global.response.CustomResponse;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
@@ -40,13 +39,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(GeneralErrorCode.VALIDATION_FAILED.getHttpStatus())
                 .body(GeneralErrorCode.VALIDATION_FAILED.getCode());
-    }
-
-    @ExceptionHandler(JwtException.class)
-    public ResponseEntity<?> handleJwtException(JwtException e) {
-        BaseErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage()));
     }
 
     @ExceptionHandler(CustomException.class)

--- a/src/main/java/com/example/kaboocampostproject/global/metadata/RedisMetadata.java
+++ b/src/main/java/com/example/kaboocampostproject/global/metadata/RedisMetadata.java
@@ -23,6 +23,9 @@ public enum RedisMetadata {
     EMAIL_VERIFIED_TOKEN_SIGNUP("EMAIL_VERIFIED_TOKEN:SIGNUP:", DataType.STRING, Duration.ofMinutes(10)),
     EMAIL_VERIFICATION_CODE_RECOVER("EMAIL_VERIFICATION_CODE:RECOVER:", DataType.STRING, Duration.ofMinutes(5)),
     EMAIL_VERIFIED_TOKEN_RECOVER("EMAIL_VERIFIED_TOKEN:RECOVER:", DataType.STRING, Duration.ofMinutes(10)),
+
+
+    LOGIN_SESSION("LOGIN_SESSION:", DataType.HASH, Duration.ofDays(30)),
     ;
 
     private final String prefix;


### PR DESCRIPTION
### 플로우
1. 로그인 시 유저 세션에 memberId, Role, tag (version) 정보를 저장 (만료 :30일) -> sessionKey와 tag 를 합친 sessionID 반환
2. 인증 시, tag를 확인하고, tag를 회전하여 sessionID 탈취감지 -> 세션 만료 (화이트리스트 제외)
3. 로그아웃 시, session 만료 및 쿠키 삭제

### Redis 에서 tag만 회전시키기로 선택한 이유.
1. redis는 기본적으로 키의 데이터를 삭제하여도, 반환된 메모리를 즉시 운영체제에 반환하지 않으므로, 잦은 api 요청 시 메모리 과다점유 문제가 발생할 것이라고 생각했습니다.
2. hash 자료구조를 사용하여 tag만 회전하기 쉽도록 구성하였습니다.
3. tag만 회전하여, 탈취 시, 탈취여부를 감지할 수 있도록 구현하였습니다