### PR TITLE
CICD : environment: production 을 제거하여 환경을 고정하지 않음

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -73,8 +73,6 @@ jobs:
   deploy-was:
     needs: build-and-push-WAS-ECR
     runs-on: ubuntu-latest
-    environment: production
-
     steps:
       # SSH Action을 사용하여 WAS 인스턴스에 원격 명령 실행
       - name: Deploy WAS via SSH and Docker
@@ -109,7 +107,7 @@ jobs:
             docker stop $CONTAINER_NAME || true
             docker rm $CONTAINER_NAME || true
 
-            # Spring Boot 앱 실행 (호스트 포트 8080 매핑)
+            # Spring 실행
             docker run -d \
               --name $CONTAINER_NAME \
               -p 8080:8080 \


### PR DESCRIPTION
- 환경 고정하는 부분 삭제,
- .dockerignore에서 build 폴더는 제외