### PR TITLE
CICD : .dockerignore 에서 build/ 폴더는 제외

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,6 @@
-**/bin/
-**/target/
-**/.gradle/
-**/.idea/
-**/.mvn/
-**/build/
-!build/libs/*.jar # 빌드된 JAR 파일은 포함해야 하므로 예외 처리
+.bin/
+target/
+.gradle/
+.idea/
+.mvn/
 *.log


### PR DESCRIPTION
- 그냥 .dockerignore 에서 build 폴더 전체 제외