### PR TITLE
refactor : 인증 허용 URL의 jwt/security 분기 제거

### DIFF
--- a/src/main/java/com/example/kaboocampostproject/global/config/SecurityProperties.java
+++ b/src/main/java/com/example/kaboocampostproject/global/config/SecurityProperties.java
@@ -18,11 +18,4 @@ public class SecurityProperties {
         this.publicApis = publicApis;
     }
 
-    public List<String> getJwtExcludePaths() {
-        return jwtExcludePaths;
-    }
-
-    public void setJwtExcludePaths(List<String> jwtExcludePaths) {
-        this.jwtExcludePaths = jwtExcludePaths;
-    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,8 +88,4 @@ app:
       - "/api/auth/signup/email-verification-code/retry"
       - "/api/auth/recover/email-verification-code"
       - "/api/members/recover"
-    jwt-exclude-paths:
-      - "/api/auth"
-      - "/api/auth/signup/**"
-      - "/api/auth/recover/**"
-
+      - "/api/health"


### PR DESCRIPTION
- 인증이 필요 없는 URL을 jwtFilter용, securityFilterChain용으로 따로 관리하던 설정 제거
- 현재는 허용된 API에 대해 securityFilterChain과 jwtFilter를 모두 통과하지 않도록 단일 화이트리스트로 처리
- 추후 CORS, 공통 커스텀 필터를 적용할 때 허용 API가 해당 필터 체인의 영향을 받지 않는 점을 고려해야 함

+추가로 alb에서 수행하는 api health check api : permit all