### PR TITLE
hotfix: presigned url 발급 실패 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,14 +52,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
 
-    // S3
-    implementation "software.amazon.awssdk:s3:2.25.11"
-
     // 타임리프
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-    // SSM
-    implementation "io.awspring.cloud:spring-cloud-aws-starter-parameter-store:3.3.0"
+    // ========== AWS ==============
+    // aws sdk의 버전을 고정 (v2) (버전 묶음 선언서)
+    implementation platform("software.amazon.awssdk:bom:2.25.40")
+    // aws cloud 의 버전을 고정 (v2)
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0")
+
+    implementation "software.amazon.awssdk:s3"
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-parameter-store"
+
 }
 
 tasks.named('test') {


### PR DESCRIPTION
ssmClient를 추가하면서, Spring Cloud AWS가 내부적으로 불러오는 AWS SDK v2 모듈들과, 프로젝트에서 직접 사용하던 aws-sdk-v2 (S3, Presigner) 모듈 사이에서 버전 충돌이 발생하여 Presigned URL 발급이 실패하는 문제가 발생하였다.

이를 해결하기 위해 AWS SDK v2 BOM과 Spring Cloud AWS BOM을 적용하여, 프로젝트 전체의 모든 AWS SDK v2 모듈들의 버전을 단일 버전으로 강제 통일함으로써 문제를 해결할 수 있었다.

기존에는 “S3와 SSM 두 개의 의존성만 사용하므로 BOM이 필요 없지 않을까?”라는 의문이 있었으나, 실제로는 각 모듈이 내부적으로 수십 개의 하위 AWS SDK 모듈들을 추가로 로딩하기 때문에, BOM은 단순히 외부에 명시된 의존성끼리만 버전을 맞추는 것이 아니라 모듈 내부까지 포함한 전체 SDK 생태계의 버전을 정렬해 주는 역할을 수행한다는 점을 이해하게 되었다.