### PR TITLE
chore: codex-gh 토큰 주입 안전성 및 재사용성 개선

### DIFF
--- a/bin/codex-gh
+++ b/bin/codex-gh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 토큰/명령 노출 방지: 상위 셸 xtrace가 켜져 있어도 비활성화
+case "$-" in
+  *x*) set +x ;;
+esac
+
+WORKDIR="${CODEX_GH_WORKDIR:-$(pwd)}"
+REPO="${CODEX_GH_REPO:-}"
+ASK_POLICY="${CODEX_ASK_POLICY:-on-request}"
+SANDBOX_MODE="${CODEX_SANDBOX_MODE:-workspace-write}"
+SKIP_PREFLIGHT="false"
+
+usage() {
+  cat <<'EOF'
+사용법: bin/codex-gh [options] [-- <extra codex args>]
+
+옵션:
+  -C, --cd <dir>          Codex 작업 디렉터리 (기본: 현재 디렉터리)
+  -R, --repo <owner/repo> preflight 확인용 저장소
+      --skip-preflight    gh 인증/권한 확인 생략
+  -h, --help              도움말 출력
+EOF
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing command: $1" >&2
+    exit 1
+  }
+}
+
+detect_repo() {
+  local remote
+  remote="$(git -C "$WORKDIR" config --get remote.origin.url 2>/dev/null || true)"
+  [[ -n "$remote" ]] || return 0
+
+  case "$remote" in
+    git@github.com:*)
+      remote="${remote#git@github.com:}"
+      ;;
+    https://github.com/*)
+      remote="${remote#https://github.com/}"
+      ;;
+    http://github.com/*)
+      remote="${remote#http://github.com/}"
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  remote="${remote%.git}"
+  printf '%s' "$remote"
+}
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -C|--cd)
+      [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 1; }
+      WORKDIR="$2"
+      shift 2
+      ;;
+    -R|--repo)
+      [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 1; }
+      REPO="$2"
+      shift 2
+      ;;
+    --skip-preflight)
+      SKIP_PREFLIGHT="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      EXTRA_ARGS+=("$@")
+      break
+      ;;
+    *)
+      EXTRA_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+require_cmd gh
+require_cmd codex
+
+export GH_PAGER=cat
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  GH_TOKEN_FROM_GH="$(gh auth token 2>/dev/null || true)"
+  if [[ -n "$GH_TOKEN_FROM_GH" ]]; then
+    export GH_TOKEN="$GH_TOKEN_FROM_GH"
+  fi
+  unset GH_TOKEN_FROM_GH
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "GH_TOKEN이 비어 있다. 먼저 실행: gh auth login -h github.com" >&2
+  exit 1
+fi
+
+export GITHUB_TOKEN="${GITHUB_TOKEN:-$GH_TOKEN}"
+
+if [[ "$SKIP_PREFLIGHT" != "true" ]]; then
+  gh auth status >/dev/null
+
+  if [[ -z "$REPO" ]]; then
+    REPO="$(detect_repo)"
+  fi
+
+  if [[ -n "$REPO" ]]; then
+    VIEWER_PERMISSION="$(gh repo view "$REPO" --json viewerPermission --jq '.viewerPermission')"
+    HAS_ISSUES="$(gh repo view "$REPO" --json hasIssuesEnabled --jq '.hasIssuesEnabled')"
+    PUSH_ALLOWED="$(gh api "repos/$REPO" --jq '.permissions.push')"
+
+    echo "Repo: $REPO"
+    echo "viewerPermission=$VIEWER_PERMISSION"
+    echo "hasIssuesEnabled=$HAS_ISSUES"
+    echo "permissions.push=$PUSH_ALLOWED"
+  fi
+fi
+
+exec codex -C "$WORKDIR" -a "$ASK_POLICY" -s "$SANDBOX_MODE" "${EXTRA_ARGS[@]}"

--- a/docs/codex-gh-session.md
+++ b/docs/codex-gh-session.md
@@ -1,0 +1,42 @@
+# Codex 세션에서 gh로 Issue/PR 직접 생성하기
+
+`bin/codex-gh` 런처는 gh 인증 토큰을 자동 주입하고 Codex를 실행한다.
+
+## 1) 1회 준비
+```bash
+gh auth login -h github.com
+```
+
+권장 토큰 권한(Fine-grained PAT):
+- `Metadata: Read`
+- `Contents: Read and write`
+- `Pull requests: Read and write`
+- `Issues: Read and write`
+
+## 2) 기본 실행
+```bash
+./bin/codex-gh
+```
+
+동작:
+- `gh auth token`으로 `GH_TOKEN` 확보
+- `GITHUB_TOKEN` 자동 동기화
+- `gh auth status` 및 repo 권한 preflight 확인
+- Codex 실행 (`-a on-request`, `-s workspace-write`)
+
+## 3) 옵션
+```bash
+./bin/codex-gh -C /path/to/repo
+./bin/codex-gh -R owner/repo
+./bin/codex-gh --skip-preflight
+```
+
+## 4) 주의사항
+- 토큰 값은 출력하지 않는다.
+- repo를 지정하지 않으면 현재 작업 디렉터리의 `remote.origin.url`에서 자동 감지한다.
+
+## 5) 실패 시 확인
+- `GH_TOKEN이 비어 있다`:
+  `gh auth login -h github.com` 재실행
+- `Resource not accessible by integration`:
+  토큰 권한/레포 권한 확인


### PR DESCRIPTION
## 작업 목적

- Codex GH 런처의 토큰 주입을 안전하게 유지하면서 재사용성을 높인다.

## 수행한 작업

- bin/codex-gh 하드코딩 경로/레포 기본값 제거
- GH_TOKEN/GITHUB_TOKEN 자동 주입 로직 유지
- xtrace 환경에서 토큰 노출 방지 처리 추가
- REPO 미지정 시 remote.origin 기반 자동 감지 추가
- docs/codex-gh-session.md를 실제 동작 기준으로 정리

## 세부 내용

- 기본 실행은 현재 디렉터리 기준으로 동작한다.
- 옵션(-C, -R, --skip-preflight)은 유지했다.
- 토큰 값은 출력하지 않는다.

## 트러블슈팅 (해당 시)

- 없음

## 검증

- bash -n bin/codex-gh
- bash ./bin/codex-gh --help
- rg -n "GH_TOKEN|GITHUB_TOKEN|echo" bin/codex-gh

## 관련 이슈

- Closes #54